### PR TITLE
chore(build): Fix build

### DIFF
--- a/src/oath/totp.rs
+++ b/src/oath/totp.rs
@@ -358,7 +358,7 @@ mod native_bindings {
     #[no_mangle]
     pub unsafe extern "C" fn totp_gen_with(totp: *mut TOTPContext, elapsed: c_ulong) -> *mut c_char {
         let totp = &*totp;
-        strings::string_to_c_char(totp.gen_with(elapsed))
+        strings::string_to_c_char(totp.gen_with(elapsed.into()))
     }
 
     #[no_mangle]


### PR DESCRIPTION
Potential compiler changes causes an issue when building.

c_ulong is considered a u32 on Windows platforms which causes mitmatched types error when building due to the code assuming it always will be a u64.