### PR TITLE
[DVLS-14228] Allow Forward TOTP Tolerance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slauth"
-version = "0.7.21"
+version = "0.7.22"
 authors = [
     "richer <richer.arc@gmail.com>",
     "LucFauvel <luc.fauvel@hotmail.com>",

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ properties.load(project.rootProject.file('local.properties').newDataInputStream(
 
 project('slauth') {
     ext {
-        libraryVersion = '0.7.21'
+        libraryVersion = '0.7.22'
     }
     publishing {
         repositories {

--- a/src/oath/totp.rs
+++ b/src/oath/totp.rs
@@ -161,7 +161,7 @@ impl TOTPContext {
             _ => {}
         }
 
-        for i in (counter - self.backward_resync)..(counter + self.forward_resync) {
+        for i in (counter - self.backward_resync)..=(counter + self.forward_resync) {
             if self.gen_at(i).as_str().eq(value) {
                 match i {
                     i if i > counter => {

--- a/wrappers/android/build.gradle
+++ b/wrappers/android/build.gradle
@@ -26,7 +26,7 @@ android {
         minSdkVersion 23
         targetSdkVersion 28
         versionCode 1
-        versionName "0.7.21"
+        versionName "0.7.22"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
[DVLS-14228](https://devolutions.atlassian.net/browse/DVLS-14228)

Fixed TOTP verification accepting codes only from the current and past time steps, but not future ones, due to an exclusive upper bound in the verify loop range. This caused authentication failures when the server clock was even slightly behind the client, while enrollment could intermittently succeed due to timing.

[RFC 6238 Section 6](https://datatracker.ietf.org/doc/html/rfc6238#section-6)

[DVLS-14228]: https://devolutions.atlassian.net/browse/DVLS-14228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ