### PR TITLE
[RDMW-21965] Add a .NET wrapper for the WebAuthn authenticator

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,6 +33,11 @@ on:
         default: true
         required: true
         type: boolean
+      nuget:
+        description: Publish a .NET version (nuget)
+        default: true
+        required: true
+        type: boolean
 
 jobs:
   build-wasm:
@@ -261,3 +266,54 @@ jobs:
       run: cloudsmith push swift devolutions/swift-public Slauth-${{ steps.version.outputs.version }}.zip --name Slauth --version ${{ steps.version.outputs.version }} --scope devolutions
       env:
         CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+
+  build-dotnet:
+    if: ${{ inputs.nuget }}
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+
+      - name: Setup rust
+        run: |
+          rustup target add x86_64-pc-windows-msvc
+          rustup target add aarch64-pc-windows-msvc
+
+      # ring needs a C compiler to cross-compile aarch64; the runner ships LLVM but not on PATH.
+      - name: Expose LLVM
+        run: echo "C:\Program Files\LLVM\bin" >> $env:GITHUB_PATH
+        shell: pwsh
+
+      - name: Configure .NET SDK
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      # Builds both Windows natives, runs the managed tests, and packs into wrappers/dotnet/package.
+      - name: Generate package
+        run: ./build.ps1
+        shell: pwsh
+        working-directory: wrappers/dotnet
+
+      - name: Read version
+        id: version
+        run: |
+          $version = (Select-String -Path Cargo.toml -Pattern '^version\s*=\s*"([^"]+)"' | Select-Object -First 1).Matches.Groups[1].Value
+          "version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+        shell: pwsh
+
+      - name: Upload package
+        uses: actions/upload-artifact@v7
+        with:
+          name: nuget
+          path: wrappers/dotnet/package/*.nupkg
+
+      - name: Publish on Artifactory
+        uses: devolutions/actions/jfrog-nuget-publish@v1
+        with:
+          artifactory_username: ${{ secrets.ARTIFACTORY_USERNAME }}
+          artifactory_password: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          push_snupkg: 'true'
+          version: ${{ steps.version.outputs.version }}
+          working_directory: wrappers/dotnet/package

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -96,3 +96,31 @@ jobs:
 
       - name: Generate package
         run: sh wrappers/swift/build.sh
+
+  build-dotnet:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v6
+
+      - name: Setup rust
+        run: |
+          rustup target add x86_64-pc-windows-msvc
+          rustup target add aarch64-pc-windows-msvc
+
+      # ring needs a C compiler to cross-compile aarch64; the runner ships LLVM but not on PATH.
+      - name: Expose LLVM
+        run: echo "C:\Program Files\LLVM\bin" >> $env:GITHUB_PATH
+        shell: pwsh
+
+      - name: Configure .NET SDK
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      # Builds both Windows natives, runs the managed tests against the real C ABI, then packs.
+      - name: Generate package
+        run: ./build.ps1
+        shell: pwsh
+        working-directory: wrappers/dotnet

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,9 @@ build/
 libslauth.xcframework/
 .swiftpm/
 package/
+
+# .NET wrapper (wrappers/dotnet)
+bin/
+obj/
+# Native libraries staged per RID by wrappers/dotnet/build.ps1 before packing
+wrappers/dotnet/Devolutions.Slauth/runtimes/

--- a/slauth.h
+++ b/slauth.h
@@ -313,3 +313,12 @@ bool is_success(struct AuthenticatorRequestResponse *res);
 char *private_key_to_pkcs8_der(const char *private_key);
 
 char *pkcs8_to_custom_private_key(const char *pkcs8_key);
+
+void request_response_free(struct AuthenticatorRequestResponse *res);
+
+/**
+ * Reclaims any `char*` this module returned; they are all `CString::into_raw` allocations and
+ * cannot be released with the caller's `free`. The buffer is wiped first because one of them
+ * (`get_private_key_from_response`) carries private key material.
+ */
+void slauth_string_free(char *s);

--- a/slauth.h
+++ b/slauth.h
@@ -317,8 +317,11 @@ char *pkcs8_to_custom_private_key(const char *pkcs8_key);
 void request_response_free(struct AuthenticatorRequestResponse *res);
 
 /**
- * Reclaims any `char*` this module returned; they are all `CString::into_raw` allocations and
- * cannot be released with the caller's `free`. The buffer is wiped first because one of them
- * (`get_private_key_from_response`) carries private key material.
+ * Reclaims any `char*` returned by this crate's native bindings. They all originate from
+ * `CString::into_raw`, so the caller's `free` is a different allocator and must not be used. The
+ * buffer is wiped first because some of these strings carry private key material.
+ *
+ * # Safety
+ * The pointer must have been produced by this crate and must not be used afterwards.
  */
 void slauth_string_free(char *s);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,27 @@ pub mod strings {
             .into_raw()
     }
 
+    /// Reclaims any `char*` returned by this crate's native bindings. They all originate from
+    /// `CString::into_raw`, so the caller's `free` is a different allocator and must not be used. The
+    /// buffer is wiped first because some of these strings carry private key material.
+    ///
+    /// # Safety
+    /// The pointer must have been produced by this crate and must not be used afterwards.
+    #[no_mangle]
+    pub unsafe extern "C" fn slauth_string_free(s: *mut c_char) {
+        if s.is_null() {
+            return;
+        }
+
+        let mut bytes = CString::from_raw(s).into_bytes_with_nul();
+        for byte in bytes.iter_mut() {
+            std::ptr::write_volatile(byte, 0);
+        }
+
+        // Keep the wipe from being optimized away now that the buffer is about to be released.
+        std::sync::atomic::compiler_fence(std::sync::atomic::Ordering::SeqCst);
+    }
+
     /// # Safety
     /// Needed to cast string in FFY context
     pub unsafe fn mut_c_char_to_string(cchar: *mut c_char) -> String {

--- a/src/webauthn/authenticator/native.rs
+++ b/src/webauthn/authenticator/native.rs
@@ -1,5 +1,13 @@
-#[cfg(target_os = "ios")]
-mod ios {
+// These bindings were originally iOS-only, but the C ABI they expose is platform-neutral and is what
+// non-Apple consumers (the .NET wrapper, and any other cdylib user) need. The enclosing module is
+// already feature-gated in mod.rs, so gate on the feature instead of the target.
+//
+// The android module below is a second C ABI over the same authenticator, shaped for Android's
+// JSON-oriented Credential Manager rather than raw CBOR. It exports four of the same symbol names with
+// different signatures, so the two modules stay mutually exclusive to keep #[no_mangle] from colliding
+// at link time.
+#[cfg(all(feature = "native-bindings", not(feature = "android")))]
+mod native_bindings {
     use crate::{
         strings,
         webauthn::{
@@ -59,6 +67,10 @@ mod ios {
 
     #[no_mangle]
     pub unsafe extern "C" fn response_free(res: *mut AuthenticatorCreationResponse) {
+        if res.is_null() {
+            return;
+        }
+
         let _ = Box::from_raw(res);
     }
 
@@ -240,6 +252,33 @@ mod ios {
             data: (*res).signature.as_mut_ptr(),
             len: (*res).signature.len(),
         }
+    }
+
+    #[no_mangle]
+    pub unsafe extern "C" fn request_response_free(res: *mut AuthenticatorRequestResponse) {
+        if res.is_null() {
+            return;
+        }
+
+        let _ = Box::from_raw(res);
+    }
+
+    /// Reclaims any `char*` this module returned; they are all `CString::into_raw` allocations and
+    /// cannot be released with the caller's `free`. The buffer is wiped first because one of them
+    /// (`get_private_key_from_response`) carries private key material.
+    #[no_mangle]
+    pub unsafe extern "C" fn slauth_string_free(s: *mut c_char) {
+        if s.is_null() {
+            return;
+        }
+
+        let mut bytes = CString::from_raw(s).into_bytes_with_nul();
+        for byte in bytes.iter_mut() {
+            std::ptr::write_volatile(byte, 0);
+        }
+
+        // Keep the wipe from being optimized away now that the buffer is about to be released.
+        std::sync::atomic::compiler_fence(std::sync::atomic::Ordering::SeqCst);
     }
 }
 

--- a/src/webauthn/authenticator/native.rs
+++ b/src/webauthn/authenticator/native.rs
@@ -263,23 +263,6 @@ mod native_bindings {
         let _ = Box::from_raw(res);
     }
 
-    /// Reclaims any `char*` this module returned; they are all `CString::into_raw` allocations and
-    /// cannot be released with the caller's `free`. The buffer is wiped first because one of them
-    /// (`get_private_key_from_response`) carries private key material.
-    #[no_mangle]
-    pub unsafe extern "C" fn slauth_string_free(s: *mut c_char) {
-        if s.is_null() {
-            return;
-        }
-
-        let mut bytes = CString::from_raw(s).into_bytes_with_nul();
-        for byte in bytes.iter_mut() {
-            std::ptr::write_volatile(byte, 0);
-        }
-
-        // Keep the wipe from being optimized away now that the buffer is about to be released.
-        std::sync::atomic::compiler_fence(std::sync::atomic::Ordering::SeqCst);
-    }
 }
 
 #[cfg(feature = "android")]

--- a/wrappers/dotnet/Devolutions.Slauth.Tests/AttestationParser.cs
+++ b/wrappers/dotnet/Devolutions.Slauth.Tests/AttestationParser.cs
@@ -1,0 +1,171 @@
+namespace Devolutions.Slauth.Tests;
+
+using System;
+using System.Formats.Cbor;
+using System.Security.Cryptography;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Crypto.Signers;
+
+/// <summary>
+/// Pulls the credential public key out of an attestation object so tests can verify an assertion
+/// signature for real, rather than just asserting the bytes are non-empty.
+/// </summary>
+internal static class AttestationParser
+{
+    internal sealed record CredentialPublicKey(
+        int Algorithm,
+        byte[]? X,
+        byte[]? Y,
+        byte[]? Modulus,
+        byte[]? Exponent);
+
+    /// <summary>Reads the authData member out of a CBOR attestation object.</summary>
+    internal static byte[] ReadAuthData(byte[] attestationObject)
+    {
+        CborReader reader = new CborReader(attestationObject);
+        int members = reader.ReadStartMap() ?? throw new InvalidOperationException("Indefinite-length attestation object.");
+        byte[]? authData = null;
+
+        for (int i = 0; i < members; i++)
+        {
+            string key = reader.ReadTextString();
+            if (key == "authData")
+            {
+                authData = reader.ReadByteString();
+            }
+            else
+            {
+                reader.SkipValue();
+            }
+        }
+
+        reader.ReadEndMap();
+        return authData ?? throw new InvalidOperationException("Attestation object has no authData.");
+    }
+
+    /// <summary>
+    /// Reads the COSE credential public key from the attested credential data.
+    /// Layout: rpIdHash(32) flags(1) signCount(4) aaguid(16) credIdLen(2) credId COSE.
+    /// </summary>
+    internal static CredentialPublicKey ReadPublicKey(byte[] authData)
+    {
+        const int AttestedCredentialDataOffset = 37;
+
+        int credentialIdLength = (authData[AttestedCredentialDataOffset + 16] << 8)
+            | authData[AttestedCredentialDataOffset + 17];
+        int coseOffset = AttestedCredentialDataOffset + 16 + 2 + credentialIdLength;
+
+        CborReader reader = new CborReader(authData[coseOffset..]);
+        int members = reader.ReadStartMap() ?? throw new InvalidOperationException("Indefinite-length COSE key.");
+
+        int algorithm = 0;
+        byte[]? x = null, y = null, modulus = null, exponent = null;
+        int keyType = 0;
+
+        for (int i = 0; i < members; i++)
+        {
+            int label = reader.ReadInt32();
+            switch (label)
+            {
+                case 1:
+                    keyType = reader.ReadInt32();
+                    break;
+                case 3:
+                    algorithm = reader.ReadInt32();
+                    break;
+                case -1:
+                    // crv for EC2/OKP, modulus for RSA — the key type disambiguates.
+                    if (keyType == 3)
+                    {
+                        modulus = reader.ReadByteString();
+                    }
+                    else
+                    {
+                        reader.SkipValue();
+                    }
+
+                    break;
+                case -2:
+                    if (keyType == 3)
+                    {
+                        exponent = reader.ReadByteString();
+                    }
+                    else
+                    {
+                        x = reader.ReadByteString();
+                    }
+
+                    break;
+                case -3:
+                    // y, but only for EC2. slauth also emits -3 on OKP keys — a bool left over from the
+                    // EC2 branch it was copied from — which RFC 8152 does not define for that key type.
+                    if (keyType == 2)
+                    {
+                        y = reader.ReadByteString();
+                    }
+                    else
+                    {
+                        reader.SkipValue();
+                    }
+
+                    break;
+                default:
+                    reader.SkipValue();
+                    break;
+            }
+        }
+
+        reader.ReadEndMap();
+        return new CredentialPublicKey(algorithm, x, y, modulus, exponent);
+    }
+
+    /// <summary>
+    /// Verifies a WebAuthn assertion signature, which covers authenticatorData concatenated with the
+    /// client data hash.
+    /// </summary>
+    internal static bool Verify(
+        CredentialPublicKey key,
+        byte[] authenticatorData,
+        byte[] clientDataHash,
+        byte[] signature)
+    {
+        byte[] signed = new byte[authenticatorData.Length + clientDataHash.Length];
+        Buffer.BlockCopy(authenticatorData, 0, signed, 0, authenticatorData.Length);
+        Buffer.BlockCopy(clientDataHash, 0, signed, authenticatorData.Length, clientDataHash.Length);
+
+        switch (key.Algorithm)
+        {
+            case (int)CoseAlgorithm.Es256:
+            {
+                using ECDsa ecdsa = ECDsa.Create(new ECParameters
+                {
+                    Curve = ECCurve.NamedCurves.nistP256,
+                    Q = new ECPoint { X = key.X, Y = key.Y },
+                });
+
+                // WebAuthn ES256 signatures are DER; accept the raw r||s form too so the test reports a
+                // genuine verification failure rather than an encoding mismatch.
+                return ecdsa.VerifyData(signed, signature, HashAlgorithmName.SHA256, DSASignatureFormat.Rfc3279DerSequence)
+                    || ecdsa.VerifyData(signed, signature, HashAlgorithmName.SHA256, DSASignatureFormat.IeeeP1363FixedFieldConcatenation);
+            }
+
+            case (int)CoseAlgorithm.Rs256:
+            {
+                using RSA rsa = RSA.Create(new RSAParameters { Modulus = key.Modulus, Exponent = key.Exponent });
+                return rsa.VerifyData(signed, signature, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+            }
+
+            case (int)CoseAlgorithm.EdDsa:
+            {
+                // .NET 10 has no Ed25519 in the BCL, so this one leans on BouncyCastle.
+                Ed25519Signer verifier = new Ed25519Signer();
+                verifier.Init(false, new Ed25519PublicKeyParameters(key.X, 0));
+                verifier.BlockUpdate(signed, 0, signed.Length);
+                return verifier.VerifySignature(signature);
+            }
+
+            default:
+                throw new NotSupportedException($"Unhandled COSE algorithm {key.Algorithm}.");
+        }
+    }
+}

--- a/wrappers/dotnet/Devolutions.Slauth.Tests/Devolutions.Slauth.Tests.csproj
+++ b/wrappers/dotnet/Devolutions.Slauth.Tests/Devolutions.Slauth.Tests.csproj
@@ -11,6 +11,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0" />
+    <PackageReference Include="System.Formats.Cbor" Version="9.0.0" />
+    <PackageReference Include="BouncyCastle.Cryptography" Version="2.6.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/wrappers/dotnet/Devolutions.Slauth.Tests/Devolutions.Slauth.Tests.csproj
+++ b/wrappers/dotnet/Devolutions.Slauth.Tests/Devolutions.Slauth.Tests.csproj
@@ -1,0 +1,39 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Devolutions.Slauth\Devolutions.Slauth.csproj" />
+  </ItemGroup>
+
+  <!--
+    These tests exercise the real C ABI, so they need the cdylib next to the test assembly.
+    Build the release cdylib at the repository root first; build.ps1 does this for you.
+  -->
+  <ItemGroup>
+    <None Include="..\..\..\target\release\slauth.dll" Condition="Exists('..\..\..\target\release\slauth.dll')">
+      <Link>slauth.dll</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\..\..\target\release\libslauth.so" Condition="Exists('..\..\..\target\release\libslauth.so')">
+      <Link>libslauth.so</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\..\..\target\release\libslauth.dylib" Condition="Exists('..\..\..\target\release\libslauth.dylib')">
+      <Link>libslauth.dylib</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/wrappers/dotnet/Devolutions.Slauth.Tests/WebAuthnTests.cs
+++ b/wrappers/dotnet/Devolutions.Slauth.Tests/WebAuthnTests.cs
@@ -98,6 +98,63 @@ public class WebAuthnTests
     }
 
     [Fact]
+    public void Create_WithExtensionDataFlag_Throws()
+    {
+        // slauth never serializes an extension map, so ED would advertise CBOR that is not there.
+        Assert.Throws<ArgumentException>(() => WebAuthnCreationResponse.Create(
+            Aaguid, NewCredentialId(), RpId, CreationFlags | AttestationFlags.ExtensionDataIncluded, CoseAlgorithm.Es256));
+    }
+
+    [Fact]
+    public void Create_WithOversizedCredentialId_Throws()
+    {
+        // The attested credential data length field is two bytes and slauth casts to u16 unchecked, so a
+        // longer id wraps and the relying party reads the overflow as the start of the COSE key.
+        byte[] oversized = new byte[WebAuthnCreationResponse.MaxCredentialIdLength + 1];
+
+        Assert.Throws<ArgumentException>(() => WebAuthnCreationResponse.Create(
+            Aaguid, oversized, RpId, CreationFlags, CoseAlgorithm.Es256));
+    }
+
+    [Fact]
+    public void Create_WithLargestPermittedCredentialId_Succeeds()
+    {
+        // Guards the boundary itself: the check must reject only what genuinely overflows the length field.
+        byte[] largest = RandomNumberGenerator.GetBytes(WebAuthnCreationResponse.MaxCredentialIdLength);
+
+        using WebAuthnCreationResponse created = WebAuthnCreationResponse.Create(
+            Aaguid, largest, RpId, CreationFlags, CoseAlgorithm.Es256);
+
+        byte[] authData = AttestationParser.ReadAuthData(created.AttestationObject);
+        int encodedLength = (authData[53] << 8) | authData[54];
+        Assert.Equal(largest.Length, encodedLength);
+    }
+
+    [Theory]
+    [InlineData(AttestationFlags.AttestedCredentialDataIncluded)]
+    [InlineData(AttestationFlags.ExtensionDataIncluded)]
+    public void Assertion_WithStructuralFlag_Throws(AttestationFlags unsupported)
+    {
+        // Both flags promise bytes the assertion path never appends: it always passes slauth None for
+        // attested credential data and slauth serializes no extensions. authenticatorData would be
+        // malformed while IsSuccess stayed true.
+        Assert.Throws<ArgumentException>(() => WebAuthnRequestResponse.Create(
+            RpId, "not-a-key", AssertionFlags | unsupported, SHA256.HashData(new byte[] { 9 })));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(31)]
+    [InlineData(33)]
+    public void Assertion_WithWrongClientDataHashLength_Throws(int length)
+    {
+        // slauth signs whatever it is handed and reports success, so a wrong-sized digest would only fail
+        // later at the relying party.
+        Assert.Throws<ArgumentException>(() => WebAuthnRequestResponse.Create(
+            RpId, "not-a-key", AssertionFlags, new byte[length]));
+    }
+
+    [Fact]
     public void Assertion_WithGarbageKey_ReportsFailureRatherThanCrashing()
     {
         // The failure path still returns a response object, so this also frees an error-message string.

--- a/wrappers/dotnet/Devolutions.Slauth.Tests/WebAuthnTests.cs
+++ b/wrappers/dotnet/Devolutions.Slauth.Tests/WebAuthnTests.cs
@@ -41,20 +41,60 @@ public class WebAuthnTests
     [InlineData(CoseAlgorithm.Es256)]
     [InlineData(CoseAlgorithm.EdDsa)]
     [InlineData(CoseAlgorithm.Rs256)]
-    public void Assertion_SignsWithTheCreatedKey(CoseAlgorithm algorithm)
+    public void Assertion_VerifiesAgainstTheAttestedPublicKey(CoseAlgorithm algorithm)
     {
+        byte[] clientDataHash = SHA256.HashData(new byte[] { 1, 2, 3, 4 });
+
         using WebAuthnCreationResponse created = WebAuthnCreationResponse.Create(
             Aaguid, NewCredentialId(), RpId, CreationFlags, algorithm);
 
         using WebAuthnRequestResponse assertion = WebAuthnRequestResponse.CreateOrThrow(
-            RpId, created.PrivateKey, AssertionFlags, SHA256.HashData(new byte[] { 1, 2, 3, 4 }));
+            RpId, created.PrivateKey, AssertionFlags, clientDataHash);
 
         Assert.True(assertion.IsSuccess);
-        Assert.NotEmpty(assertion.Signature);
 
         // authenticatorData is rpIdHash(32) + flags(1) + signCount(4) at minimum.
         Assert.True(assertion.AuthenticatorData.Length >= 37);
         Assert.Equal(SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(RpId)), assertion.AuthenticatorData[..32]);
+
+        // The signature must actually verify against the public key the registration attested, which is
+        // what a relying party checks. Non-empty bytes would pass an incorrectly signed assertion.
+        byte[] authData = AttestationParser.ReadAuthData(created.AttestationObject);
+        AttestationParser.CredentialPublicKey publicKey = AttestationParser.ReadPublicKey(authData);
+
+        Assert.Equal((int)algorithm, publicKey.Algorithm);
+        Assert.True(
+            AttestationParser.Verify(publicKey, assertion.AuthenticatorData, clientDataHash, assertion.Signature),
+            $"{algorithm} assertion did not verify against the attested public key.");
+    }
+
+    [Fact]
+    public void Assertion_DoesNotVerifyForADifferentChallenge()
+    {
+        byte[] clientDataHash = SHA256.HashData(new byte[] { 1, 2, 3, 4 });
+
+        using WebAuthnCreationResponse created = WebAuthnCreationResponse.Create(
+            Aaguid, NewCredentialId(), RpId, CreationFlags, CoseAlgorithm.Es256);
+
+        using WebAuthnRequestResponse assertion = WebAuthnRequestResponse.CreateOrThrow(
+            RpId, created.PrivateKey, AssertionFlags, clientDataHash);
+
+        byte[] authData = AttestationParser.ReadAuthData(created.AttestationObject);
+        AttestationParser.CredentialPublicKey publicKey = AttestationParser.ReadPublicKey(authData);
+
+        // Guards the verification helper itself: if it returned true unconditionally, the test above
+        // would pass no matter what slauth produced.
+        byte[] otherHash = SHA256.HashData(new byte[] { 9, 9, 9, 9 });
+        Assert.False(
+            AttestationParser.Verify(publicKey, assertion.AuthenticatorData, otherHash, assertion.Signature));
+    }
+
+    [Fact]
+    public void Create_WithoutAttestedCredentialDataFlag_Throws()
+    {
+        // slauth would omit the attested credential data and still report success, so the wrapper rejects it.
+        Assert.Throws<ArgumentException>(() => WebAuthnCreationResponse.Create(
+            Aaguid, NewCredentialId(), RpId, AttestationFlags.UserPresent, CoseAlgorithm.Es256));
     }
 
     [Fact]

--- a/wrappers/dotnet/Devolutions.Slauth.Tests/WebAuthnTests.cs
+++ b/wrappers/dotnet/Devolutions.Slauth.Tests/WebAuthnTests.cs
@@ -1,0 +1,117 @@
+namespace Devolutions.Slauth.Tests;
+
+using System;
+using System.Security.Cryptography;
+using Devolutions.Slauth;
+using Xunit;
+
+/// <summary>
+/// Round-trips the real C ABI: create a credential, sign an assertion with the key it produced, and
+/// convert that key to PKCS#8 and back. These also cover the string and response free paths, so a
+/// regression in the ownership rules shows up as a crash here rather than as a slow leak in a consumer.
+/// </summary>
+public class WebAuthnTests
+{
+    // Arbitrary 16-byte fixture. Nothing here asserts on it; slauth only splices it into the attested
+    // credential data, so the value is irrelevant to what these tests check.
+    private const string Aaguid = "0F0E0D0C0B0A09080706050403020100";
+
+    private const string RpId = "webauthn.io";
+
+    private static readonly AttestationFlags CreationFlags =
+        AttestationFlags.UserPresent | AttestationFlags.UserVerified | AttestationFlags.AttestedCredentialDataIncluded;
+
+    private static readonly AttestationFlags AssertionFlags =
+        AttestationFlags.UserPresent | AttestationFlags.UserVerified;
+
+    [Theory]
+    [InlineData(CoseAlgorithm.Es256)]
+    [InlineData(CoseAlgorithm.EdDsa)]
+    [InlineData(CoseAlgorithm.Rs256)]
+    public void Create_ProducesPrivateKeyAndAttestationObject(CoseAlgorithm algorithm)
+    {
+        using WebAuthnCreationResponse created = WebAuthnCreationResponse.Create(
+            Aaguid, NewCredentialId(), RpId, CreationFlags, algorithm);
+
+        Assert.False(string.IsNullOrWhiteSpace(created.PrivateKey));
+        Assert.NotEmpty(created.AttestationObject);
+    }
+
+    [Theory]
+    [InlineData(CoseAlgorithm.Es256)]
+    [InlineData(CoseAlgorithm.EdDsa)]
+    [InlineData(CoseAlgorithm.Rs256)]
+    public void Assertion_SignsWithTheCreatedKey(CoseAlgorithm algorithm)
+    {
+        using WebAuthnCreationResponse created = WebAuthnCreationResponse.Create(
+            Aaguid, NewCredentialId(), RpId, CreationFlags, algorithm);
+
+        using WebAuthnRequestResponse assertion = WebAuthnRequestResponse.CreateOrThrow(
+            RpId, created.PrivateKey, AssertionFlags, SHA256.HashData(new byte[] { 1, 2, 3, 4 }));
+
+        Assert.True(assertion.IsSuccess);
+        Assert.NotEmpty(assertion.Signature);
+
+        // authenticatorData is rpIdHash(32) + flags(1) + signCount(4) at minimum.
+        Assert.True(assertion.AuthenticatorData.Length >= 37);
+        Assert.Equal(SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(RpId)), assertion.AuthenticatorData[..32]);
+    }
+
+    [Fact]
+    public void Assertion_WithGarbageKey_ReportsFailureRatherThanCrashing()
+    {
+        // The failure path still returns a response object, so this also frees an error-message string.
+        using WebAuthnRequestResponse assertion = WebAuthnRequestResponse.Create(
+            RpId, "not-a-key", AssertionFlags, SHA256.HashData(new byte[] { 9 }));
+
+        Assert.False(assertion.IsSuccess);
+    }
+
+    [Fact]
+    public void Assertion_WithGarbageKey_OrThrowThrows()
+    {
+        Assert.Throws<SlauthException>(() => WebAuthnRequestResponse.CreateOrThrow(
+            RpId, "not-a-key", AssertionFlags, SHA256.HashData(new byte[] { 9 })));
+    }
+
+    [Fact]
+    public void PrivateKey_RoundTripsThroughPkcs8()
+    {
+        using WebAuthnCreationResponse created = WebAuthnCreationResponse.Create(
+            Aaguid, NewCredentialId(), RpId, CreationFlags, CoseAlgorithm.Es256);
+
+        string pkcs8 = PrivateKeyConverter.ToPkcs8Der(created.PrivateKey);
+        Assert.False(string.IsNullOrWhiteSpace(pkcs8));
+
+        string envelope = PrivateKeyConverter.FromPkcs8Der(pkcs8);
+        Assert.False(string.IsNullOrWhiteSpace(envelope));
+
+        // The recovered envelope must still sign, which is the property consumers actually depend on.
+        using WebAuthnRequestResponse assertion = WebAuthnRequestResponse.CreateOrThrow(
+            RpId, envelope, AssertionFlags, SHA256.HashData(new byte[] { 7 }));
+
+        Assert.True(assertion.IsSuccess);
+    }
+
+    [Fact]
+    public void Create_WithNoAlgorithms_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => WebAuthnCreationResponse.Create(
+            Aaguid, NewCredentialId(), RpId, CreationFlags));
+    }
+
+    [Fact]
+    public void Create_RepeatedlyDoesNotFault()
+    {
+        // Exercises the create/free cycle enough times that a double free or a bad free surfaces.
+        for (int i = 0; i < 50; i++)
+        {
+            using WebAuthnCreationResponse created = WebAuthnCreationResponse.Create(
+                Aaguid, NewCredentialId(), RpId, CreationFlags, CoseAlgorithm.Es256);
+
+            Assert.False(string.IsNullOrWhiteSpace(created.PrivateKey));
+        }
+    }
+
+    private static byte[] NewCredentialId() => RandomNumberGenerator.GetBytes(16);
+}

--- a/wrappers/dotnet/Devolutions.Slauth/Devolutions.Slauth.csproj
+++ b/wrappers/dotnet/Devolutions.Slauth/Devolutions.Slauth.csproj
@@ -1,0 +1,37 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <!-- netstandard2.0 defaults to C# 7.3, which predates nullable annotations and file-scoped namespaces. -->
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <AssemblyName>Devolutions.Slauth</AssemblyName>
+    <RootNamespace>Devolutions.Slauth</RootNamespace>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PackageId>Devolutions.Slauth</PackageId>
+    <!-- Overridden by CI from the crate version; see wrappers/dotnet/build.ps1. -->
+    <Version>0.0.0-dev</Version>
+    <Authors>Devolutions Inc</Authors>
+    <Description>Managed bindings for slauth's WebAuthn authenticator: credential creation, assertion signing, and PKCS#8 conversion.</Description>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageProjectUrl>https://github.com/Devolutions/slauth</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/Devolutions/slauth</RepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <!--
+    Native libraries are staged here per RID by build.ps1 before packing, so the package ships
+    runtimes/<rid>/native/slauth.dll and the .NET host resolves DllImport("slauth") automatically.
+    Adding a platform is just another staged RID folder — no change needed here.
+  -->
+  <ItemGroup>
+    <None Include="runtimes/**" Pack="true" PackagePath="runtimes/" CopyToOutputDirectory="Never" />
+    <None Include="../README.md" Pack="true" PackagePath="/" />
+  </ItemGroup>
+
+</Project>

--- a/wrappers/dotnet/Devolutions.Slauth/Native.cs
+++ b/wrappers/dotnet/Devolutions.Slauth/Native.cs
@@ -1,0 +1,189 @@
+namespace Devolutions.Slauth;
+
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+
+/// <summary>
+/// Raw P/Invoke surface over slauth's C ABI (see slauth.h at the repository root).
+/// </summary>
+/// <remarks>
+/// Three ownership rules apply to everything declared here, and the public wrapper types are what
+/// enforce them:
+/// <list type="bullet">
+/// <item>Response pointers must be released with their matching free function — hence the SafeHandles.</item>
+/// <item><c>char*</c> returns are Rust <c>CString::into_raw</c> allocations. They must go back through
+/// <c>slauth_string_free</c>; the caller's <c>free</c> is a different allocator.</item>
+/// <item>A returned <see cref="Buffer"/> borrows the response's own storage, so it is only valid until
+/// the response is freed. Copy out before releasing the handle.</item>
+/// </list>
+/// </remarks>
+internal static class Native
+{
+    private const string Library = "slauth";
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct Buffer
+    {
+        public IntPtr Data;
+        public UIntPtr Len;
+    }
+
+    [DllImport(Library, EntryPoint = "generate_credential_creation_response", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern CreationResponseHandle GenerateCredentialCreationResponse(
+        IntPtr aaguid,
+        byte[] credentialId,
+        UIntPtr credentialIdLength,
+        IntPtr rpId,
+        byte attestationFlags,
+        int[] coseAlgorithmIdentifiers,
+        UIntPtr coseAlgorithmIdentifiersLength);
+
+    [DllImport(Library, EntryPoint = "get_private_key_from_response", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern IntPtr GetPrivateKeyFromResponse(CreationResponseHandle response);
+
+    [DllImport(Library, EntryPoint = "get_attestation_object_from_response", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern Buffer GetAttestationObjectFromResponse(CreationResponseHandle response);
+
+    [DllImport(Library, EntryPoint = "response_free", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern void ResponseFree(IntPtr response);
+
+    [DllImport(Library, EntryPoint = "generate_credential_request_response", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern RequestResponseHandle GenerateCredentialRequestResponse(
+        IntPtr rpId,
+        IntPtr privateKey,
+        byte attestationFlags,
+        byte[] clientDataHash,
+        UIntPtr clientDataHashLength);
+
+    [DllImport(Library, EntryPoint = "get_auth_data_from_response", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern Buffer GetAuthDataFromResponse(RequestResponseHandle response);
+
+    [DllImport(Library, EntryPoint = "get_signature_from_response", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern Buffer GetSignatureFromResponse(RequestResponseHandle response);
+
+    [DllImport(Library, EntryPoint = "is_success", CallingConvention = CallingConvention.Cdecl)]
+    [return: MarshalAs(UnmanagedType.I1)]
+    internal static extern bool IsSuccess(RequestResponseHandle response);
+
+    [DllImport(Library, EntryPoint = "get_error_message", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern IntPtr GetErrorMessage(RequestResponseHandle response);
+
+    [DllImport(Library, EntryPoint = "request_response_free", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern void RequestResponseFree(IntPtr response);
+
+    [DllImport(Library, EntryPoint = "private_key_to_pkcs8_der", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern IntPtr PrivateKeyToPkcs8Der(IntPtr privateKey);
+
+    [DllImport(Library, EntryPoint = "pkcs8_to_custom_private_key", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern IntPtr Pkcs8ToCustomPrivateKey(IntPtr pkcs8Key);
+
+    [DllImport(Library, EntryPoint = "slauth_string_free", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern void SlauthStringFree(IntPtr value);
+
+    /// <summary>Copies a borrowed buffer out before its owning response is released.</summary>
+    internal static byte[] CopyBuffer(Buffer buffer)
+    {
+        if (buffer.Data == IntPtr.Zero || (ulong)buffer.Len == 0)
+        {
+            return Array.Empty<byte>();
+        }
+
+        byte[] copy = new byte[(int)(ulong)buffer.Len];
+        Marshal.Copy(buffer.Data, copy, 0, copy.Length);
+        return copy;
+    }
+}
+
+/// <summary>
+/// UTF-8 marshalling done by hand: slauth reads Rust <c>CStr</c>, so the platform's default ANSI
+/// marshalling would corrupt any non-ASCII value (a relying party id can be an IDN).
+/// </summary>
+internal static class Utf8
+{
+    /// <summary>Allocates a NUL-terminated UTF-8 copy. Release with <see cref="Free"/>.</summary>
+    internal static IntPtr Allocate(string? value)
+    {
+        if (value is null)
+        {
+            return IntPtr.Zero;
+        }
+
+        byte[] bytes = Encoding.UTF8.GetBytes(value);
+        IntPtr pointer = Marshal.AllocHGlobal(bytes.Length + 1);
+        Marshal.Copy(bytes, 0, pointer, bytes.Length);
+        Marshal.WriteByte(pointer, bytes.Length, 0);
+        return pointer;
+    }
+
+    internal static void Free(IntPtr pointer)
+    {
+        if (pointer != IntPtr.Zero)
+        {
+            Marshal.FreeHGlobal(pointer);
+        }
+    }
+
+    /// <summary>
+    /// Reads a NUL-terminated UTF-8 string that slauth allocated, then hands the allocation back to
+    /// slauth. Never use the caller's <c>free</c> here — the string came from Rust.
+    /// </summary>
+    internal static string? ConsumeSlauthString(IntPtr pointer)
+    {
+        if (pointer == IntPtr.Zero)
+        {
+            return null;
+        }
+
+        try
+        {
+            int length = 0;
+            while (Marshal.ReadByte(pointer, length) != 0)
+            {
+                length++;
+            }
+
+            byte[] bytes = new byte[length];
+            Marshal.Copy(pointer, bytes, 0, length);
+            return Encoding.UTF8.GetString(bytes);
+        }
+        finally
+        {
+            Native.SlauthStringFree(pointer);
+        }
+    }
+}
+
+/// <summary>Owns an <c>AuthenticatorCreationResponse*</c>.</summary>
+internal sealed class CreationResponseHandle : SafeHandle
+{
+    public CreationResponseHandle()
+        : base(IntPtr.Zero, true)
+    {
+    }
+
+    public override bool IsInvalid => this.handle == IntPtr.Zero;
+
+    protected override bool ReleaseHandle()
+    {
+        Native.ResponseFree(this.handle);
+        return true;
+    }
+}
+
+/// <summary>Owns an <c>AuthenticatorRequestResponse*</c>.</summary>
+internal sealed class RequestResponseHandle : SafeHandle
+{
+    public RequestResponseHandle()
+        : base(IntPtr.Zero, true)
+    {
+    }
+
+    public override bool IsInvalid => this.handle == IntPtr.Zero;
+
+    protected override bool ReleaseHandle()
+    {
+        Native.RequestResponseFree(this.handle);
+        return true;
+    }
+}

--- a/wrappers/dotnet/Devolutions.Slauth/WebAuthn.cs
+++ b/wrappers/dotnet/Devolutions.Slauth/WebAuthn.cs
@@ -1,0 +1,298 @@
+namespace Devolutions.Slauth;
+
+using System;
+
+/// <summary>authenticatorData flag bits (WebAuthn §6.1).</summary>
+[Flags]
+public enum AttestationFlags : byte
+{
+    /// <summary>No flags set.</summary>
+    None = 0,
+
+    /// <summary>UP: the user was present.</summary>
+    UserPresent = 1,
+
+    /// <summary>UV: the user was verified.</summary>
+    UserVerified = 4,
+
+    /// <summary>BE: the credential may be backed up.</summary>
+    BackupEligible = 8,
+
+    /// <summary>BS: the credential is currently backed up.</summary>
+    BackedUp = 16,
+
+    /// <summary>AT: attested credential data follows. Required when creating a credential.</summary>
+    AttestedCredentialDataIncluded = 64,
+
+    /// <summary>ED: extension data follows.</summary>
+    ExtensionDataIncluded = 128,
+}
+
+/// <summary>COSE algorithm identifiers slauth can create and sign with.</summary>
+public enum CoseAlgorithm
+{
+    /// <summary>ECDSA over P-256 with SHA-256.</summary>
+    Es256 = -7,
+
+    /// <summary>EdDSA over Ed25519.</summary>
+    EdDsa = -8,
+
+    /// <summary>RSASSA-PKCS1-v1_5 with SHA-256.</summary>
+    Rs256 = -257,
+}
+
+/// <summary>Raised when slauth rejects a request or cannot produce a result.</summary>
+public class SlauthException : Exception
+{
+    /// <summary>Initializes a new instance with the supplied message.</summary>
+    public SlauthException(string message)
+        : base(message)
+    {
+    }
+}
+
+/// <summary>
+/// A credential created by the authenticator: the generated private key plus the attestation object
+/// to hand back to the relying party.
+/// </summary>
+public sealed class WebAuthnCreationResponse : IDisposable
+{
+    private readonly CreationResponseHandle handle;
+
+    private WebAuthnCreationResponse(CreationResponseHandle handle)
+    {
+        this.handle = handle;
+        this.PrivateKey = Utf8.ConsumeSlauthString(Native.GetPrivateKeyFromResponse(handle))
+            ?? throw new SlauthException("slauth returned no private key for the created credential.");
+        this.AttestationObject = Native.CopyBuffer(Native.GetAttestationObjectFromResponse(handle));
+    }
+
+    /// <summary>The generated private key, in slauth's own credential envelope.</summary>
+    public string PrivateKey { get; }
+
+    /// <summary>CBOR attestation object (fmt "none").</summary>
+    public byte[] AttestationObject { get; }
+
+    /// <summary>Generates a credential and its attestation object.</summary>
+    /// <param name="aaguid">Authenticator AAGUID as hex, without separators.</param>
+    /// <param name="credentialId">Credential id to embed in the attested credential data.</param>
+    /// <param name="rpId">Relying party id; its SHA-256 becomes the rpIdHash in authenticatorData.</param>
+    /// <param name="attestationFlags">
+    /// authenticatorData flags. Include <see cref="AttestationFlags.AttestedCredentialDataIncluded"/>.
+    /// </param>
+    /// <param name="algorithms">
+    /// Algorithms the relying party will accept, in preference order. slauth picks the first it supports.
+    /// </param>
+    public static WebAuthnCreationResponse Create(
+        string aaguid,
+        byte[] credentialId,
+        string rpId,
+        AttestationFlags attestationFlags,
+        params CoseAlgorithm[] algorithms)
+    {
+        if (aaguid is null)
+        {
+            throw new ArgumentNullException(nameof(aaguid));
+        }
+
+        if (credentialId is null)
+        {
+            throw new ArgumentNullException(nameof(credentialId));
+        }
+
+        if (rpId is null)
+        {
+            throw new ArgumentNullException(nameof(rpId));
+        }
+
+        if (algorithms is null || algorithms.Length == 0)
+        {
+            throw new ArgumentException("At least one algorithm is required.", nameof(algorithms));
+        }
+
+        int[] rawAlgorithms = new int[algorithms.Length];
+        for (int i = 0; i < algorithms.Length; i++)
+        {
+            rawAlgorithms[i] = (int)algorithms[i];
+        }
+
+        IntPtr aaguidPointer = Utf8.Allocate(aaguid);
+        IntPtr rpIdPointer = Utf8.Allocate(rpId);
+        try
+        {
+            CreationResponseHandle handle = Native.GenerateCredentialCreationResponse(
+                aaguidPointer,
+                credentialId,
+                (UIntPtr)credentialId.Length,
+                rpIdPointer,
+                (byte)attestationFlags,
+                rawAlgorithms,
+                (UIntPtr)rawAlgorithms.Length);
+
+            if (handle.IsInvalid)
+            {
+                handle.Dispose();
+                throw new SlauthException(
+                    "slauth rejected the credential creation request (check the aaguid, rpId, and algorithm list).");
+            }
+
+            // Reads everything out of the response while the handle is alive; the caller only ever sees
+            // owned managed copies.
+            return new WebAuthnCreationResponse(handle);
+        }
+        finally
+        {
+            Utf8.Free(aaguidPointer);
+            Utf8.Free(rpIdPointer);
+        }
+    }
+
+    /// <summary>Releases the underlying slauth response.</summary>
+    public void Dispose() => this.handle.Dispose();
+}
+
+/// <summary>An assertion produced by signing a relying party's challenge with a stored credential.</summary>
+public sealed class WebAuthnRequestResponse : IDisposable
+{
+    private readonly RequestResponseHandle handle;
+
+    private WebAuthnRequestResponse(RequestResponseHandle handle)
+    {
+        this.handle = handle;
+        this.IsSuccess = Native.IsSuccess(handle);
+        this.ErrorMessage = Utf8.ConsumeSlauthString(Native.GetErrorMessage(handle));
+        this.AuthenticatorData = Native.CopyBuffer(Native.GetAuthDataFromResponse(handle));
+        this.Signature = Native.CopyBuffer(Native.GetSignatureFromResponse(handle));
+    }
+
+    /// <summary>Whether slauth produced a usable assertion.</summary>
+    public bool IsSuccess { get; }
+
+    /// <summary>Failure detail from slauth; empty or null when <see cref="IsSuccess"/> is true.</summary>
+    public string? ErrorMessage { get; }
+
+    /// <summary>authenticatorData that was signed.</summary>
+    public byte[] AuthenticatorData { get; }
+
+    /// <summary>Signature over authenticatorData concatenated with the client data hash.</summary>
+    public byte[] Signature { get; }
+
+    /// <summary>
+    /// Signs <paramref name="clientDataHash"/> with <paramref name="privateKey"/>. slauth reports a failed
+    /// assertion through the response rather than a null handle, so inspect <see cref="IsSuccess"/>; use
+    /// <see cref="CreateOrThrow"/> to turn that into an exception.
+    /// </summary>
+    public static WebAuthnRequestResponse Create(
+        string rpId,
+        string privateKey,
+        AttestationFlags attestationFlags,
+        byte[] clientDataHash)
+    {
+        if (rpId is null)
+        {
+            throw new ArgumentNullException(nameof(rpId));
+        }
+
+        if (privateKey is null)
+        {
+            throw new ArgumentNullException(nameof(privateKey));
+        }
+
+        if (clientDataHash is null)
+        {
+            throw new ArgumentNullException(nameof(clientDataHash));
+        }
+
+        IntPtr rpIdPointer = Utf8.Allocate(rpId);
+        IntPtr privateKeyPointer = Utf8.Allocate(privateKey);
+        try
+        {
+            RequestResponseHandle handle = Native.GenerateCredentialRequestResponse(
+                rpIdPointer,
+                privateKeyPointer,
+                (byte)attestationFlags,
+                clientDataHash,
+                (UIntPtr)clientDataHash.Length);
+
+            if (handle.IsInvalid)
+            {
+                handle.Dispose();
+                throw new SlauthException("slauth rejected the assertion request.");
+            }
+
+            return new WebAuthnRequestResponse(handle);
+        }
+        finally
+        {
+            Utf8.Free(rpIdPointer);
+            Utf8.Free(privateKeyPointer);
+        }
+    }
+
+    /// <summary>Signs as <see cref="Create"/> does, throwing when slauth reports failure.</summary>
+    public static WebAuthnRequestResponse CreateOrThrow(
+        string rpId,
+        string privateKey,
+        AttestationFlags attestationFlags,
+        byte[] clientDataHash)
+    {
+        WebAuthnRequestResponse response = Create(rpId, privateKey, attestationFlags, clientDataHash);
+        if (!response.IsSuccess)
+        {
+            string message = string.IsNullOrEmpty(response.ErrorMessage)
+                ? "slauth could not produce an assertion."
+                : response.ErrorMessage!;
+            response.Dispose();
+            throw new SlauthException(message);
+        }
+
+        return response;
+    }
+
+    /// <summary>Releases the underlying slauth response.</summary>
+    public void Dispose() => this.handle.Dispose();
+}
+
+/// <summary>Converts between slauth's credential envelope and PKCS#8.</summary>
+public static class PrivateKeyConverter
+{
+    /// <summary>Converts a slauth credential envelope to base64 PKCS#8 DER.</summary>
+    public static string ToPkcs8Der(string privateKey)
+    {
+        if (privateKey is null)
+        {
+            throw new ArgumentNullException(nameof(privateKey));
+        }
+
+        IntPtr pointer = Utf8.Allocate(privateKey);
+        try
+        {
+            return Utf8.ConsumeSlauthString(Native.PrivateKeyToPkcs8Der(pointer))
+                ?? throw new SlauthException("slauth could not convert the private key to PKCS#8.");
+        }
+        finally
+        {
+            Utf8.Free(pointer);
+        }
+    }
+
+    /// <summary>Converts base64 PKCS#8 DER into slauth's credential envelope.</summary>
+    public static string FromPkcs8Der(string pkcs8Key)
+    {
+        if (pkcs8Key is null)
+        {
+            throw new ArgumentNullException(nameof(pkcs8Key));
+        }
+
+        IntPtr pointer = Utf8.Allocate(pkcs8Key);
+        try
+        {
+            return Utf8.ConsumeSlauthString(Native.Pkcs8ToCustomPrivateKey(pointer))
+                ?? throw new SlauthException("slauth could not convert the PKCS#8 key.");
+        }
+        finally
+        {
+            Utf8.Free(pointer);
+        }
+    }
+}

--- a/wrappers/dotnet/Devolutions.Slauth/WebAuthn.cs
+++ b/wrappers/dotnet/Devolutions.Slauth/WebAuthn.cs
@@ -110,6 +110,15 @@ public sealed class WebAuthnCreationResponse : IDisposable
             throw new ArgumentException("At least one algorithm is required.", nameof(algorithms));
         }
 
+        // Without AT, slauth omits the attested credential data and still reports success, yielding an
+        // attestation object no relying party can use. Fail here rather than hand back a broken credential.
+        if ((attestationFlags & AttestationFlags.AttestedCredentialDataIncluded) == 0)
+        {
+            throw new ArgumentException(
+                "AttestedCredentialDataIncluded is required when creating a credential.",
+                nameof(attestationFlags));
+        }
+
         int[] rawAlgorithms = new int[algorithms.Length];
         for (int i = 0; i < algorithms.Length; i++)
         {

--- a/wrappers/dotnet/Devolutions.Slauth/WebAuthn.cs
+++ b/wrappers/dotnet/Devolutions.Slauth/WebAuthn.cs
@@ -24,8 +24,29 @@ public enum AttestationFlags : byte
     /// <summary>AT: attested credential data follows. Required when creating a credential.</summary>
     AttestedCredentialDataIncluded = 64,
 
-    /// <summary>ED: extension data follows.</summary>
+    /// <summary>
+    /// ED: extension data follows. Defined for completeness only — slauth never serializes an extension
+    /// map, so both entry points reject this flag.
+    /// </summary>
     ExtensionDataIncluded = 128,
+}
+
+/// <summary>Flag checks shared by the registration and assertion paths.</summary>
+internal static class AttestationFlagGuard
+{
+    /// <summary>
+    /// Rejects ED on either path. slauth's <c>AuthenticatorData::to_vec</c> never serializes an extension
+    /// map, so the bit would advertise a CBOR map that no consumer will find.
+    /// </summary>
+    internal static void RejectExtensionData(AttestationFlags attestationFlags)
+    {
+        if ((attestationFlags & AttestationFlags.ExtensionDataIncluded) != 0)
+        {
+            throw new ArgumentException(
+                "ExtensionDataIncluded is not supported; slauth does not serialize extension data.",
+                nameof(attestationFlags));
+        }
+    }
 }
 
 /// <summary>COSE algorithm identifiers slauth can create and sign with.</summary>
@@ -57,6 +78,9 @@ public class SlauthException : Exception
 /// </summary>
 public sealed class WebAuthnCreationResponse : IDisposable
 {
+    /// <summary>Largest credential id the attested credential data's two-byte length field can hold.</summary>
+    public const int MaxCredentialIdLength = ushort.MaxValue;
+
     private readonly CreationResponseHandle handle;
 
     private WebAuthnCreationResponse(CreationResponseHandle handle)
@@ -75,10 +99,13 @@ public sealed class WebAuthnCreationResponse : IDisposable
 
     /// <summary>Generates a credential and its attestation object.</summary>
     /// <param name="aaguid">Authenticator AAGUID as hex, without separators.</param>
-    /// <param name="credentialId">Credential id to embed in the attested credential data.</param>
+    /// <param name="credentialId">
+    /// Credential id to embed in the attested credential data; at most <see cref="MaxCredentialIdLength"/> bytes.
+    /// </param>
     /// <param name="rpId">Relying party id; its SHA-256 becomes the rpIdHash in authenticatorData.</param>
     /// <param name="attestationFlags">
-    /// authenticatorData flags. Include <see cref="AttestationFlags.AttestedCredentialDataIncluded"/>.
+    /// authenticatorData flags. Must include <see cref="AttestationFlags.AttestedCredentialDataIncluded"/>
+    /// and must not include <see cref="AttestationFlags.ExtensionDataIncluded"/>.
     /// </param>
     /// <param name="algorithms">
     /// Algorithms the relying party will accept, in preference order. slauth picks the first it supports.
@@ -117,6 +144,18 @@ public sealed class WebAuthnCreationResponse : IDisposable
             throw new ArgumentException(
                 "AttestedCredentialDataIncluded is required when creating a credential.",
                 nameof(attestationFlags));
+        }
+
+        AttestationFlagGuard.RejectExtensionData(attestationFlags);
+
+        // The attested credential data encodes this length in two bytes, and slauth casts to u16 without
+        // checking, so a longer id wraps while every byte is still written and the relying party reads
+        // the overflow as the start of the COSE key.
+        if (credentialId.Length > MaxCredentialIdLength)
+        {
+            throw new ArgumentException(
+                $"Credential id must be at most {MaxCredentialIdLength} bytes; got {credentialId.Length}.",
+                nameof(credentialId));
         }
 
         int[] rawAlgorithms = new int[algorithms.Length];
@@ -163,6 +202,9 @@ public sealed class WebAuthnCreationResponse : IDisposable
 /// <summary>An assertion produced by signing a relying party's challenge with a stored credential.</summary>
 public sealed class WebAuthnRequestResponse : IDisposable
 {
+    /// <summary>Length of the SHA-256 client data hash WebAuthn signs over.</summary>
+    public const int ClientDataHashLength = 32;
+
     private readonly RequestResponseHandle handle;
 
     private WebAuthnRequestResponse(RequestResponseHandle handle)
@@ -191,6 +233,16 @@ public sealed class WebAuthnRequestResponse : IDisposable
     /// assertion through the response rather than a null handle, so inspect <see cref="IsSuccess"/>; use
     /// <see cref="CreateOrThrow"/> to turn that into an exception.
     /// </summary>
+    /// <param name="rpId">Relying party id; its SHA-256 becomes the rpIdHash in authenticatorData.</param>
+    /// <param name="privateKey">A private key in slauth's credential envelope.</param>
+    /// <param name="attestationFlags">
+    /// authenticatorData flags. Structural flags belong to registration, so neither
+    /// <see cref="AttestationFlags.AttestedCredentialDataIncluded"/> nor
+    /// <see cref="AttestationFlags.ExtensionDataIncluded"/> may be set here.
+    /// </param>
+    /// <param name="clientDataHash">
+    /// The <see cref="ClientDataHashLength"/>-byte SHA-256 digest of the collected client data.
+    /// </param>
     public static WebAuthnRequestResponse Create(
         string rpId,
         string privateKey,
@@ -210,6 +262,26 @@ public sealed class WebAuthnRequestResponse : IDisposable
         if (clientDataHash is null)
         {
             throw new ArgumentNullException(nameof(clientDataHash));
+        }
+
+        // The assertion ABI has no way to pass attested credential data — it always hands slauth None — so
+        // AT here only sets a bit promising a payload that never gets appended.
+        if ((attestationFlags & AttestationFlags.AttestedCredentialDataIncluded) != 0)
+        {
+            throw new ArgumentException(
+                "AttestedCredentialDataIncluded is not valid for an assertion; it belongs to registration.",
+                nameof(attestationFlags));
+        }
+
+        AttestationFlagGuard.RejectExtensionData(attestationFlags);
+
+        // clientDataHash is a SHA-256 digest by definition. slauth signs whatever length it is given and
+        // still reports success, so a wrong-sized hash only fails later at the relying party.
+        if (clientDataHash.Length != ClientDataHashLength)
+        {
+            throw new ArgumentException(
+                $"clientDataHash must be a {ClientDataHashLength}-byte SHA-256 digest; got {clientDataHash.Length} bytes.",
+                nameof(clientDataHash));
         }
 
         IntPtr rpIdPointer = Utf8.Allocate(rpId);

--- a/wrappers/dotnet/README.md
+++ b/wrappers/dotnet/README.md
@@ -1,0 +1,82 @@
+# Devolutions.Slauth
+
+Managed bindings for slauth's WebAuthn authenticator: credential creation, assertion signing, and
+conversion between slauth's credential envelope and PKCS#8.
+
+The package ships the native library per RID under `runtimes/<rid>/native/`, so the .NET host resolves
+`DllImport("slauth")` with no extra setup from the consumer.
+
+## Usage
+
+```csharp
+using Devolutions.Slauth;
+
+// Create a credential. slauth generates the key pair and returns the private key in its own envelope.
+using WebAuthnCreationResponse created = WebAuthnCreationResponse.Create(
+    aaguid:           "0F0E0D0C0B0A09080706050403020100",
+    credentialId:     credentialId,
+    rpId:             "example.com",
+    attestationFlags: AttestationFlags.UserPresent
+                      | AttestationFlags.UserVerified
+                      | AttestationFlags.AttestedCredentialDataIncluded,
+    CoseAlgorithm.Es256, CoseAlgorithm.Rs256, CoseAlgorithm.EdDsa);
+
+string privateKey = created.PrivateKey;              // store this
+byte[] attestation = created.AttestationObject;      // return this to the relying party
+
+// Later, sign an assertion with the stored key.
+using WebAuthnRequestResponse assertion = WebAuthnRequestResponse.CreateOrThrow(
+    rpId:             "example.com",
+    privateKey:       privateKey,
+    attestationFlags: AttestationFlags.UserPresent | AttestationFlags.UserVerified,
+    clientDataHash:   clientDataHash);
+
+byte[] authenticatorData = assertion.AuthenticatorData;
+byte[] signature = assertion.Signature;
+```
+
+`Create` reports a failed assertion through `IsSuccess`/`ErrorMessage`; `CreateOrThrow` turns that into
+a `SlauthException`.
+
+To move a key between slauth's envelope and PKCS#8:
+
+```csharp
+string pkcs8 = PrivateKeyConverter.ToPkcs8Der(privateKey);
+string envelope = PrivateKeyConverter.FromPkcs8Der(pkcs8);
+```
+
+## Ownership rules the wrapper handles for you
+
+The C ABI has three rules that are easy to get wrong, so the wrapper enforces all of them and never
+exposes a raw pointer:
+
+- Response pointers are owned by `SafeHandle`s, so they are always released.
+- `char*` returns are Rust `CString::into_raw` allocations and must go back through
+  `slauth_string_free` — the caller's `free` is a different allocator.
+- A returned `Buffer` borrows the response's own storage, so it is only valid until the response is
+  freed. Every byte array the wrapper hands out is an owned managed copy taken while the handle is alive.
+
+## Building
+
+```powershell
+./build.ps1
+```
+
+Builds the cdylib for each target, stages it into `Devolutions.Slauth/runtimes/<rid>/native/`, runs the
+managed tests, and packs. Defaults to `win-x64` and `win-arm64`; pass `-Targets` for others and
+`-SkipTests` to skip the test run.
+
+Adding a platform means one entry in `$RidByTarget` in `build.ps1` — the wrapper and csproj need no change.
+
+### Prerequisite for cross-compiling
+
+`ring` needs a C compiler for some targets. Building `aarch64-pc-windows-msvc` requires LLVM/clang on
+`PATH`; without it the build fails with `failed to find tool "clang"`. GitHub's Windows runners already
+ship LLVM. The host-architecture build (`x86_64-pc-windows-msvc`) does not need it.
+
+## Tests
+
+The tests exercise the real C ABI rather than a mock — they create credentials for ES256, EdDSA and
+RS256, sign assertions, verify the rpIdHash, round-trip a key through PKCS#8 and confirm it still signs,
+and loop the create/free cycle so a bad free surfaces as a crash. They need the host cdylib in
+`target/release`, which `build.ps1` produces.

--- a/wrappers/dotnet/README.md
+++ b/wrappers/dotnet/README.md
@@ -38,6 +38,18 @@ byte[] signature = assertion.Signature;
 `Create` reports a failed assertion through `IsSuccess`/`ErrorMessage`; `CreateOrThrow` turns that into
 a `SlauthException`.
 
+### Arguments the wrapper rejects
+
+slauth signs whatever it is handed and reports success, so inputs that produce authenticatorData no
+relying party can parse are rejected up front with an `ArgumentException` rather than surfacing as a
+puzzling failure at the relying party:
+
+- `AttestedCredentialDataIncluded` is **required** when creating a credential and **rejected** on an
+  assertion — the assertion ABI has no way to pass attested credential data.
+- `ExtensionDataIncluded` is rejected on both paths; slauth never serializes an extension map.
+- `clientDataHash` must be exactly 32 bytes, the SHA-256 digest WebAuthn defines.
+- `credentialId` must fit the attested credential data's two-byte length field (65535 bytes).
+
 To move a key between slauth's envelope and PKCS#8:
 
 ```csharp

--- a/wrappers/dotnet/build.ps1
+++ b/wrappers/dotnet/build.ps1
@@ -1,0 +1,118 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Builds the native slauth libraries and packs the Devolutions.Slauth NuGet package.
+
+.DESCRIPTION
+    Cross-compiles the cdylib for each requested Rust target, stages the result into the wrapper's
+    runtimes/<rid>/native folder so the .NET host can resolve DllImport("slauth"), then packs.
+
+    Adding a platform means adding one entry to $RidByTarget and passing the target; nothing else in
+    the wrapper or the csproj needs to change.
+
+.PARAMETER Targets
+    Rust target triples to build. Defaults to the two Windows targets the Desktop Extension ships.
+
+.PARAMETER Version
+    Package version. Defaults to the crate version read from Cargo.toml.
+
+.PARAMETER SkipTests
+    Skip the managed test run. The tests exercise the real C ABI, so leave them on where possible.
+#>
+[CmdletBinding()]
+param(
+    [string[]] $Targets = @('x86_64-pc-windows-msvc', 'aarch64-pc-windows-msvc'),
+    [string] $Version,
+    [string] $Configuration = 'Release',
+    [string] $OutputPath = './package',
+    [switch] $SkipTests
+)
+
+$ErrorActionPreference = 'Stop'
+
+$RidByTarget = @{
+    'x86_64-pc-windows-msvc'    = @{ Rid = 'win-x64';     File = 'slauth.dll' }
+    'aarch64-pc-windows-msvc'   = @{ Rid = 'win-arm64';   File = 'slauth.dll' }
+    'i686-pc-windows-msvc'      = @{ Rid = 'win-x86';     File = 'slauth.dll' }
+    'x86_64-unknown-linux-gnu'  = @{ Rid = 'linux-x64';   File = 'libslauth.so' }
+    'aarch64-unknown-linux-gnu' = @{ Rid = 'linux-arm64'; File = 'libslauth.so' }
+    'x86_64-apple-darwin'       = @{ Rid = 'osx-x64';     File = 'libslauth.dylib' }
+    'aarch64-apple-darwin'      = @{ Rid = 'osx-arm64';   File = 'libslauth.dylib' }
+}
+
+$WrapperDir = $PSScriptRoot
+$RepoRoot = Resolve-Path (Join-Path $WrapperDir '../..')
+$ProjectDir = Join-Path $WrapperDir 'Devolutions.Slauth'
+$RuntimesDir = Join-Path $ProjectDir 'runtimes'
+
+if (-not $Version) {
+    $cargoToml = Get-Content (Join-Path $RepoRoot 'Cargo.toml')
+    # Take the first version key, which belongs to [package]; dependency versions come later.
+    $Version = ($cargoToml | Select-String -Pattern '^version\s*=\s*"([^"]+)"' | Select-Object -First 1).Matches.Groups[1].Value
+    if (-not $Version) {
+        throw 'Could not read the crate version from Cargo.toml. Pass -Version explicitly.'
+    }
+}
+
+Write-Host "Packing Devolutions.Slauth $Version" -ForegroundColor Cyan
+
+# Start from a clean runtimes tree so a removed target can't leave a stale native behind in the package.
+if (Test-Path $RuntimesDir) {
+    Remove-Item $RuntimesDir -Recurse -Force
+}
+
+foreach ($target in $Targets) {
+    if (-not $RidByTarget.ContainsKey($target)) {
+        throw "Unknown Rust target '$target'. Add it to `$RidByTarget in this script."
+    }
+
+    $mapping = $RidByTarget[$target]
+
+    Write-Host "==> $target ($($mapping.Rid))" -ForegroundColor Yellow
+
+    Push-Location $RepoRoot
+    try {
+        & rustup target add $target
+        if ($LASTEXITCODE -ne 0) { throw "rustup target add $target failed." }
+
+        & cargo build --release --target $target
+        if ($LASTEXITCODE -ne 0) { throw "cargo build for $target failed." }
+    }
+    finally {
+        Pop-Location
+    }
+
+    $built = Join-Path $RepoRoot "target/$target/release/$($mapping.File)"
+    if (-not (Test-Path $built)) {
+        throw "Expected native library not found: $built"
+    }
+
+    $destination = Join-Path $RuntimesDir "$($mapping.Rid)/native"
+    New-Item $destination -ItemType Directory -Force | Out-Null
+    Copy-Item $built (Join-Path $destination $mapping.File) -Force
+}
+
+if (-not $SkipTests) {
+    # The test project loads the host-architecture cdylib from target/release, so make sure it exists.
+    Push-Location $RepoRoot
+    try {
+        & cargo build --release
+        if ($LASTEXITCODE -ne 0) { throw 'cargo build (host) failed.' }
+    }
+    finally {
+        Pop-Location
+    }
+
+    Write-Host '==> Running managed tests' -ForegroundColor Yellow
+    & dotnet test (Join-Path $WrapperDir 'Devolutions.Slauth.Tests/Devolutions.Slauth.Tests.csproj') --configuration $Configuration
+    if ($LASTEXITCODE -ne 0) { throw 'Managed tests failed.' }
+}
+
+Write-Host '==> Packing' -ForegroundColor Yellow
+& dotnet pack (Join-Path $ProjectDir 'Devolutions.Slauth.csproj') `
+    --configuration $Configuration `
+    --output $OutputPath `
+    -p:Version=$Version
+if ($LASTEXITCODE -ne 0) { throw 'dotnet pack failed.' }
+
+Write-Host "Done. Packages in $OutputPath" -ForegroundColor Green

--- a/wrappers/swift/classes/Hotp.swift
+++ b/wrappers/swift/classes/Hotp.swift
@@ -39,7 +39,7 @@ public class Hotp: NSObject, RustObject {
 	public func to_uri(label: String, issuer: String) -> String {
 		let uri = hotp_to_uri(raw, label, issuer)
 		let s = String(cString: uri!)
-		free(uri)
+		slauth_string_free(uri)
 		return s
 	}
 	
@@ -50,7 +50,7 @@ public class Hotp: NSObject, RustObject {
 	public func gen() -> String {
 		let code = hotp_gen(raw)
 		let s_code = String(cString: code!)
-		free(code)
+		slauth_string_free(code)
 		return s_code
 	}
 	

--- a/wrappers/swift/classes/SlauthUtils.swift
+++ b/wrappers/swift/classes/SlauthUtils.swift
@@ -8,14 +8,14 @@ public class SlauthUtils {
      public static func convertPkcs8ToPrivateKey(pkcs8String: String) -> String {
         let cString = pkcs8_to_custom_private_key(pkcs8String)
         let privateKey = String(cString: cString!)
-        free(cString)
+        slauth_string_free(cString)
         return privateKey
     }
 
     public static func convertPrivateKeyToPkcs8(privateKey: String) -> String {
         let cString = private_key_to_pkcs8_der(privateKey)
         let pkcs8String = String(cString: cString!)
-        free(cString)
+        slauth_string_free(cString)
         return pkcs8String
     }
 }

--- a/wrappers/swift/classes/Totp.swift
+++ b/wrappers/swift/classes/Totp.swift
@@ -39,21 +39,21 @@ public class Totp: NSObject, RustObject {
 	public func to_uri(label: String, issuer: String) -> String {
 		let uri = totp_to_uri(raw, label, issuer)
 		let s = String(cString: uri!)
-		free(uri)
+		slauth_string_free(uri)
 		return s
 	}
 	
 	public func gen() -> String {
 		let code = totp_gen(raw)
 		let s = String(cString: code!)
-		free(code)
+		slauth_string_free(code)
 		return s
 	}
 	
 	public func gen_with(elapsed: UInt) -> String {
 		let code = totp_gen_with(raw, elapsed)
 		let s = String(cString: code!)
-		free(code)
+		slauth_string_free(code)
 		return s
 	}
 	

--- a/wrappers/swift/classes/U2f.swift
+++ b/wrappers/swift/classes/U2f.swift
@@ -51,7 +51,7 @@ public class WebRequest : RustObject {
 		}
 		
 		let origin = String(cString: cOrigin!)
-		free(cOrigin)
+		slauth_string_free(cOrigin)
 		return .some(origin)
 	}
 	
@@ -67,7 +67,7 @@ public class WebRequest : RustObject {
 			}
 			
 			let keyHandle = String(cString: cKeyHandle!)
-			free(cKeyHandle)
+			slauth_string_free(cKeyHandle)
 			return .some(keyHandle)
 		} else {
 			return .none
@@ -112,14 +112,14 @@ public class SigningKey: RustObject {
 	public func getKeyHandle() -> String {
 		let cString = signing_key_get_key_handle(raw)
 		let keyHandle = String(cString: cString!)
-		free(cString)
+		slauth_string_free(cString)
 		return keyHandle
 	}
 	
 	public func toString() -> String {
 		let csString = signing_key_to_string(raw)
 		let sign = String(cString: csString!)
-		free(csString)
+		slauth_string_free(csString)
 		return sign
 	}
 }
@@ -151,7 +151,7 @@ public class WebResponse: RustObject {
 	public func toJson() -> String {
 		let cJsonString = client_web_response_to_json(raw)
 		let json = String(cString: cJsonString!)
-		free(cJsonString)
+		slauth_string_free(cJsonString)
 		return json
 	}
 }

--- a/wrappers/swift/classes/WebAuthnCreationResponse.swift
+++ b/wrappers/swift/classes/WebAuthnCreationResponse.swift
@@ -23,7 +23,7 @@ public class WebAuthnCreationResponse: NSObject {
     public func getPrivateKey() -> String {
         let cString = get_private_key_from_response(self.raw)
         let privateKey = String(cString: cString!)
-        free(cString)
+        slauth_string_free(cString)
         return privateKey
     }
 

--- a/wrappers/swift/classes/WebAuthnRequestResponse.swift
+++ b/wrappers/swift/classes/WebAuthnRequestResponse.swift
@@ -34,7 +34,7 @@ public class WebAuthnRequestResponse: NSObject, RustObject {
     public func getErrorMessage() -> String {
         let cString = get_error_message(self.raw)
         let errorMessage = String(cString: cString!)
-        free(cString)
+        slauth_string_free(cString)
         return errorMessage
     }
 
@@ -54,5 +54,9 @@ public class WebAuthnRequestResponse: NSObject, RustObject {
             self.init(raw: r!)
         }
         clientDataHashPointer.deallocate()
+    }
+
+    deinit {
+        request_response_free(raw)
     }
 }


### PR DESCRIPTION
- [🔗 RDMW-21965](https://devolutions.atlassian.net/browse/RDMW-21965)

The RDM Desktop Extension acts as a Windows WebAuthn plugin and currently reimplements slauth's credential
envelope, COSE encoding and assertion signing by hand in C#, which risks drifting from the format Hub
writes through `slauth-web`. This adds a .NET wrapper so it can call slauth instead.

The authenticator C ABI was gated on `target_os = "ios"`, so nothing declared in `slauth.h` existed on any
other platform. The ABI is platform-neutral, so it is gated on the `native-bindings` feature instead,
matching `oath` and `u2f`. The `not(feature = "android")` half is required rather than cosmetic: the
android module exports four of the same symbol names with different signatures and they would collide at
link time. iOS is unaffected.

Three leaks in that ABI are also fixed. `slauth_string_free` reclaims the `char*` returns — they are
`CString::into_raw` allocations, so the caller's `free` is the wrong allocator, which is what the swift
wrapper currently does; the private key string is wiped before release. `request_response_free` releases
`AuthenticatorRequestResponse`, which had no free function at all, so every assertion leaked. And
`response_free` now null-checks.

The wrapper exposes no raw pointers: `SafeHandle`s own the handles, strings go back through
`slauth_string_free`, and because `Buffer` borrows the response's storage every byte array handed out is an
owned copy. `build.ps1` cross-compiles, stages natives per RID, tests and packs. `rust.yml` gains a
`build-dotnet` job and `publish.yml` a `nuget` input. Tests run against the real ABI: all three algorithms,
assertion signing, a PKCS#8 round trip, and a create/free loop.